### PR TITLE
Fix for empty display names in Address headers

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
@@ -59,6 +59,9 @@ public final class ByteBuffer extends AbstractBuffer {
      */
     @Override
     public Buffer readBytes(final int length) throws IndexOutOfBoundsException {
+        if (length == 0) {
+            return Buffers.EMPTY_BUFFER;
+        }
         checkReadableBytes(length);
         final int lowerBoundary = this.readerIndex + this.lowerBoundary;
         this.readerIndex += length;

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/address/impl/AddressImpl.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/address/impl/AddressImpl.java
@@ -128,6 +128,16 @@ public final class AddressImpl implements Address {
         final Buffer displayName = SipParser.consumeDisplayName(buffer);
         boolean leftAngleBracket = true;
 
+        // handle the case of an address that looks like:
+        // "" <sip:alice@example.com>
+        // where the two double quotes is the ones that
+        // caused a problem. This checks for that case and
+        // consumes any potential white space that is left
+        // after the consumption of that weird display name
+        if (doubleQuote && displayName.isEmpty()) {
+            SipParser.consumeWS(buffer);
+        }
+
         // if no display name, then there may be a '<' present
         // and if so, consume it.
         if (displayName.isEmpty() && buffer.peekByte() == SipParser.LAQUOT) {

--- a/pkts-sip/src/test/java/io/pkts/packet/sip/address/impl/AddressImplTest.java
+++ b/pkts-sip/src/test/java/io/pkts/packet/sip/address/impl/AddressImplTest.java
@@ -10,7 +10,6 @@ import io.pkts.buffer.Buffers;
 import io.pkts.packet.sip.address.Address;
 import io.pkts.packet.sip.address.SipURI;
 import io.pkts.packet.sip.address.URI;
-import io.pkts.packet.sip.address.impl.AddressImpl;
 
 import org.junit.After;
 import org.junit.Before;
@@ -108,6 +107,12 @@ public class AddressImplTest {
         buffer = Buffers.wrap("sip:example.com");
         address = AddressImpl.parse(buffer);
         assertThat(address.getURI().toString(), is("sip:example.com"));
+
+        // Empty display name
+        buffer = Buffers.wrap("\"\" <sip:alice@example.com>");
+        address = AddressImpl.parse(buffer);
+        assertThat(address.getDisplayName().isEmpty(), is(true));
+        assertThat(address.getURI().toString(), is("sip:alice@example.com"));
     }
 
     /**

--- a/pkts-sip/src/test/java/io/pkts/packet/sip/header/impl/AddressParameterHeadersTestBase.java
+++ b/pkts-sip/src/test/java/io/pkts/packet/sip/header/impl/AddressParameterHeadersTestBase.java
@@ -13,7 +13,6 @@ import io.pkts.packet.sip.address.Address;
 import io.pkts.packet.sip.address.SipURI;
 import io.pkts.packet.sip.header.FromHeader;
 import io.pkts.packet.sip.header.ToHeader;
-import io.pkts.packet.sip.header.impl.AddressParametersHeaderImpl;
 
 import org.junit.After;
 import org.junit.Before;
@@ -176,6 +175,14 @@ public abstract class AddressParameterHeadersTestBase {
         assertThat(to.getParameter("lr").isEmpty(), is(true));
         assertThat(to.getParameter("hello").toString(), is("world"));
         assertThat(to.getParameter("apa").toString(), is("monkey"));
+    }
+
+    @Test
+    public void testEmptyDisplayName() throws Exception {
+        final AddressParametersHeaderImpl to = frameHeader(Buffers.wrap("\"\" <sip:alice@example.com>;tag=asdf-asdf-asdf"));
+        assertThat(to.getAddress().getDisplayName().toString(), is(""));
+        assertThat(to.getParameter("lr"), is((Buffer)null));
+        assertThat(to.getParameter("tag").toString(), is("asdf-asdf-asdf"));
     }
 
 }

--- a/pkts-sip/src/test/java/io/pkts/packet/sip/impl/SipParserTest.java
+++ b/pkts-sip/src/test/java/io/pkts/packet/sip/impl/SipParserTest.java
@@ -174,6 +174,15 @@ public class SipParserTest {
         assertThat(SipParser.consumeQuotedString(buffer).toString(), is("hello world"));
         assertThat(buffer.toString(), is(""));
 
+        // Empty quoted string
+        buffer = Buffers.wrap("\"\" <sip:hello@world.com>");
+        assertThat(SipParser.consumeQuotedString(buffer).toString(), is(""));
+        assertThat(buffer.toString(), is(" <sip:hello@world.com>"));
+
+        buffer = Buffers.wrap("\"\"");
+        assertThat(SipParser.consumeQuotedString(buffer).toString(), is(""));
+        assertThat(buffer.toString(), is(""));
+
         buffer = Buffers.wrap("\"hello\"");
         assertThat(SipParser.consumeQuotedString(buffer).toString(), is("hello"));
         assertThat(buffer.toString(), is(""));

--- a/pkts-streams/src/test/java/io/pkts/streams/impl/DefaultStreamHandlerTest.java
+++ b/pkts-streams/src/test/java/io/pkts/streams/impl/DefaultStreamHandlerTest.java
@@ -190,6 +190,14 @@ public class DefaultStreamHandlerTest extends StreamsTestBase {
         public int packetCount;
         public int endCount;
 
+        public List<Stream<SipPacket>> getStreams() {
+            return this.streams;
+        }
+
+        public Stream<SipPacket> getFirstStream() {
+            return this.streams.get(0);
+        }
+
         @Override
         public void startStream(final Stream<SipPacket> stream, final SipPacket packet) {
             this.streams.add(stream);


### PR DESCRIPTION
- If you had "" sip:hello@world.com it didnt parse correctly. Fixed that.
- Added a check for zero in Buffer.readBytes and returns Buffers.EMPTY_BUFFER instead.
