### PR TITLE
Unused private fields should be removed

### DIFF
--- a/pkts-core/src/main/java/io/pkts/framer/SllFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/SllFramer.java
@@ -33,21 +33,6 @@ public class SllFramer implements Framer<PCapPacket> {
     private static final byte LINUX_SLL_OUTGOING = (byte) 0x04;
 
     /**
-     * See pcap/sll.h for explanation of what this is. Also note that these
-     * values are actually two bytes starting with 0x00 but I left that out
-     * here.
-     * 
-     * Novell 802.3 frames without 802.2 LLC header
-     * 
-     */
-    private static final byte LINUX_SLL_P_802_3 = (byte) 0x01;
-
-    /**
-     * 802.2 frames (not D/I/X Ethernet)
-     */
-    private static final byte LINUX_SLL_P_802_2 = (byte) 0x04;
-
-    /**
      * 
      */
     public SllFramer() {

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/AddressParametersHeader.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/AddressParametersHeader.java
@@ -82,8 +82,6 @@ public interface AddressParametersHeader extends SipHeader, HeaderAddress, Param
 
         private Address.Builder addressBuilder;
 
-        private Buffer value;
-
         /**
          * Note these are the header parameters and are not to be confused with any URI parameters
          * that are "attached" to the URI within the address object.

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/ViaHeader.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/ViaHeader.java
@@ -242,7 +242,6 @@ public interface ViaHeader extends Parameters, SipHeader {
         private static final Buffer BRANCH = Buffers.wrap("branch");
         private static final Buffer RECEIVED = Buffers.wrap("received");
         private static final Buffer RPORT = Buffers.wrap("rport");
-        private static final Buffer TTL = Buffers.wrap("ttl");
 
         private int indexOfBranch;
 
@@ -254,8 +253,6 @@ public interface ViaHeader extends Parameters, SipHeader {
         private Buffer host;
         private int port;
         private List<Buffer[]> params;
-
-        private Buffer branch;
 
         public Builder() {
             params = new ArrayList<>(3);

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
@@ -50,8 +50,6 @@ public final class ParametersSupport {
      */
     private boolean isDirty;
 
-    private final int estimatedSize = 0;
-
     public ParametersSupport() {
         this(null);
     }

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipMessageBuilder.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipMessageBuilder.java
@@ -38,18 +38,8 @@ public abstract class SipMessageBuilder<T extends SipMessage> implements SipMess
      */
     private final List<SipHeader> headers;
 
-    /**
-     * All headers added to this builder is subject
-     * to filtering.
-     */
-    private Predicate<SipHeader> filter;
-
     private Function<SipURI, SipURI> onRequestURIFunction;
 
-    private CSeqHeader cseq;
-    private CSeqHeader.Builder cseqBuilder;
-
-    private MaxForwardsHeader maxForwards;
     private Consumer<MaxForwardsHeader.Builder> onMaxForwardsBuilder;
 
     private Consumer<AddressParametersHeader.Builder<ToHeader>> onToBuilder;

--- a/pkts-streams/src/main/java/io/pkts/streams/impl/RtpStreamHandler.java
+++ b/pkts-streams/src/main/java/io/pkts/streams/impl/RtpStreamHandler.java
@@ -25,8 +25,6 @@ import org.slf4j.LoggerFactory;
  */
 public class RtpStreamHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(RtpStreamHandler.class);
-
     private StreamListener<RtpPacket> rtpListener;
 
     private final Map<Long, DefaultRtpStream> streams = new HashMap<Long, DefaultRtpStream>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1068 Unused private fields should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1068

Please let me know if you have any questions.

Zeeshan Asghar
