### PR TITLE
Public constants and fields initialized at declaration should be 'static final' rather than merely 'final'

### DIFF
--- a/pkts-core/src/main/java/io/pkts/packet/impl/TransportPacketFactoryImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/TransportPacketFactoryImpl.java
@@ -24,7 +24,7 @@ public final class TransportPacketFactoryImpl implements TransportPacketFactory 
      * Raw Ethernet II frame with a source and destination mac address of
      * 00:00:00:00:00:00 and the type is set to IP (0800 - the last two bytes).
      */
-    private final byte[] ehternetII = new byte[] {
+    private static final byte[] ehternetII = new byte[] {
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x08, (byte) 0x00 };
 
@@ -33,7 +33,7 @@ public final class TransportPacketFactoryImpl implements TransportPacketFactory 
      * protocol for UDP. The length and checksums must be corrected when
      * generating a new packet based on this template.
      */
-    private final byte[] ipv4 = new byte[] {
+    private static final byte[] ipv4 = new byte[] {
             (byte) 0x45, (byte) 0x00, (byte) 0x01, (byte) 0xed, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
             (byte) 0x40, (byte) 0x11, (byte) 0x3a, (byte) 0xfe, (byte) 0x7f, (byte) 0x00, (byte) 0x00, (byte) 0x01,
             (byte) 0x7f, (byte) 0x00, (byte) 0x00, (byte) 0x01 };
@@ -44,13 +44,13 @@ public final class TransportPacketFactoryImpl implements TransportPacketFactory 
      * on your payload but you also need to re-calculate the checksum. And you
      * probably want to
      */
-    private final byte[] udp = new byte[] {
+    private static final byte[] udp = new byte[] {
             (byte) 0x13, (byte) 0xe2, (byte) 0x13, (byte) 0xc4, (byte) 0x00, (byte) 0x00, (byte) 0xff, (byte) 0xec };
 
     /**
      * The total size of an empty UDP packet.
      */
-    private final int udpLength = this.ehternetII.length + this.ipv4.length + this.udp.length;
+    private static final int udpLength = ehternetII.length + ipv4.length + udp.length;
 
     /**
      * A reference to the main {@link PacketFactory}

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
@@ -50,7 +50,7 @@ public final class ParametersSupport {
      */
     private boolean isDirty;
 
-    private final int estimatedSize = 0;
+    private static final int estimatedSize = 0;
 
     public ParametersSupport() {
         this(null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1170 Public constants and fields initialized at declaration should be 'static final' rather than merely 'final'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1170 

Please let me know if you have any questions.

Zeeshan Asghar