### PR TITLE
Unused local variables should be removed

### DIFF
--- a/pkts-core/src/main/java/io/pkts/Pcap.java
+++ b/pkts-core/src/main/java/io/pkts/Pcap.java
@@ -68,9 +68,7 @@ public class Pcap {
     }
 
     public void loop(final PacketHandler callback) throws IOException {
-        final ByteOrder byteOrder = this.header.getByteOrder();
         final PcapFramer framer = new PcapFramer(this.header, this.framerManager);
-        int count = 1;
 
         Packet packet = null;
         boolean processNext = true;

--- a/pkts-core/src/main/java/io/pkts/framer/IPv4Framer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/IPv4Framer.java
@@ -47,7 +47,6 @@ public class IPv4Framer implements Framer<MACPacket> {
         // final int version = ((i >>> 28) & 0x0F);
         // final int length = ((i >>> 24) & 0x0F);
 
-        final int version = b >>> 5 & 0x0F;
         final int length = b & 0x0F;
 
         // byte 2 - dscp and ecn

--- a/pkts-core/src/main/java/io/pkts/framer/RTPFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/RTPFramer.java
@@ -98,9 +98,7 @@ public final class RTPFramer implements Framer<TransportPacket> {
             final int csrcCount = b & 0x0F;
 
             if (hasExtension) {
-                final short extensionHeaders = buffer.readShort();
                 final int length = buffer.readUnsignedShort();
-                final Buffer extensionData = buffer.readBytes(length);
             }
 
             if (hasPadding || hasExtension || csrcCount > 0) {

--- a/pkts-examples/src/main/java/io/pkts/examples/siplib/SipLibExample001.java
+++ b/pkts-examples/src/main/java/io/pkts/examples/siplib/SipLibExample001.java
@@ -43,16 +43,6 @@ public class SipLibExample001 {
         // Strings, Buffers and byte-arrays.
         final SipMessage msg = SipMessage.frame(rawMessage);
 
-        // Once the message has successfully been parsed you
-        // can access headers etc within the SIP message.
-        final FromHeader from = msg.getFromHeader();
-
-        // All headers that typically are needed for any application, and
-        // in particular for SIP stacks, have explicit methods and returns
-        // explicit objects. You may still use the generic getHeader but then
-        // you will get a generic SIP header back.
-        final ContactHeader contact = msg.getContactHeader();
-
         // Instead of having to do SipMessage.getMethod().equals("BYE") etc
         // the SIP message has many convenience methods for making the code
         // more readable, less error prone and less boiler place to write.

--- a/pkts-sdp/src/main/java/io/pkts/sdp/impl/SDPWrapper.java
+++ b/pkts-sdp/src/main/java/io/pkts/sdp/impl/SDPWrapper.java
@@ -74,7 +74,6 @@ public class SDPWrapper implements SDP {
             throws SdpParseException {
         final Media m = md.getMedia();
         if ("RTP/AVP".equalsIgnoreCase(m.getProtocol())) {
-            final Connection c = md.getConnection() != null ? null : connection;
             return new RTPInfoImpl(connection, md);
         }
         return null;

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/address/SipURI.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/address/SipURI.java
@@ -619,7 +619,6 @@ public interface SipURI extends URI {
         public SipURI build() throws SipParseException {
             assertNotEmpty(this.host, "Host cannot be empty");
 
-            final Buffer scheme = isSecure ? SipParser.SCHEME_SIPS_COLON : SipParser.SCHEME_SIP_COLON;
             final Buffer params = this.paramSupport.toBuffer();
             if (params != null) {
                 size += params.capacity();

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
@@ -2013,7 +2013,6 @@ public class SipParser {
             // payload (or end of message)
         }
 
-        final Buffer headers = buffer.slice(startHeaders, buffer.getReaderIndex());
         Buffer payload = null;
         if (buffer.hasReadableBytes()) {
             payload = buffer.slice();
@@ -2037,10 +2036,6 @@ public class SipParser {
         final int startIndex = buffer.getReaderIndex();
 
         final SipInitialLine initialLine = SipInitialLine.parse(buffer.readLine());
-
-        // which means that the headers are about
-        // to start now.
-        final int startHeaders = buffer.getReaderIndex();
 
         // Move along as long as we actually can consume an header and
         Buffer headerName = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1481  Unused local variables should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1481

Please let me know if you have any questions.

Zeeshan Asghar
