### PR TITLE
'private' methods that don't access instance data should be 'static'

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/AbstractBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/AbstractBuffer.java
@@ -200,7 +200,7 @@ public abstract class AbstractBuffer implements Buffer {
         return index;
     }
 
-    private boolean isByteInArray(final byte b, final byte[] bytes) {
+    private static boolean isByteInArray(final byte b, final byte[] bytes) {
         for (final byte x : bytes) {
             if (x == b) {
                 return true;

--- a/pkts-core/src/main/java/io/pkts/framer/SllFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/SllFramer.java
@@ -129,11 +129,11 @@ public class SllFramer implements Framer<PCapPacket> {
         }
     }
 
-    private boolean isKnownEtherType(final byte b1, final byte b2) {
+    private static boolean isKnownEtherType(final byte b1, final byte b2) {
         return EthernetFramer.getEtherTypeSafe(b1, b2) != null;
     }
 
-    private boolean validatePacketType(final byte b1, final byte b2) {
+    private static boolean validatePacketType(final byte b1, final byte b2) {
         if (b1 != (byte) 0x00) {
             return false;
         }

--- a/pkts-sdp/src/main/java/io/pkts/sdp/impl/SDPWrapper.java
+++ b/pkts-sdp/src/main/java/io/pkts/sdp/impl/SDPWrapper.java
@@ -70,7 +70,7 @@ public class SDPWrapper implements SDP {
      *         of type "RTP/AVP", otherwise null.
      * @throws SdpParseException
      */
-    private RTPInfo processMediaDescription(final Connection connection, final MediaDescription md)
+    private static RTPInfo processMediaDescription(final Connection connection, final MediaDescription md)
             throws SdpParseException {
         final Media m = md.getMedia();
         if ("RTP/AVP".equalsIgnoreCase(m.getProtocol())) {

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/address/Address.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/address/Address.java
@@ -453,7 +453,7 @@ public interface Address {
             return new AddressImpl(addressBuf, this.displayName, uri);
         }
 
-        private boolean doubleQuoteIt(final Buffer buffer) {
+        private static boolean doubleQuoteIt(final Buffer buffer) {
             try {
                 // Don't think a display name would be longer than 1k but if
                 // it is and there is a space after that 1k then this fails...

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/impl/ParametersSupport.java
@@ -228,7 +228,7 @@ public final class ParametersSupport {
      * 
      * @return
      */
-    private Buffer allcoateNewParamBuffer() {
+    private static Buffer allcoateNewParamBuffer() {
         // TODO: actually do what we claim that we are doing
         // and figure out how big of a buffer we need.
         return Buffers.createBuffer(256);

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipMessageBuilder.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipMessageBuilder.java
@@ -505,7 +505,7 @@ public abstract class SipMessageBuilder<T extends SipMessage> implements SipMess
         return this.onRequestURIFunction;
     }
 
-    private <T> List<T> ensureList(List<T> list) {
+    private static <T> List<T> ensureList(List<T> list) {
         if (list != null)  {
             return list;
         }
@@ -540,7 +540,7 @@ public abstract class SipMessageBuilder<T extends SipMessage> implements SipMess
      * @param list
      * @return
      */
-    private final int sizeOf(final List<?> list) {
+    private static final int sizeOf(final List<?> list) {
         return list == null ? 0 : list.size() - 1;
     }
 
@@ -896,7 +896,7 @@ public abstract class SipMessageBuilder<T extends SipMessage> implements SipMess
      * @param <T>
      * @return the chained consumer (or the new consumer if there previously wasn't one around)
      */
-    private <T> Consumer<T> chainConsumers(final Consumer<T> currentConsumer, final Consumer<T> consumer) {
+    private static <T> Consumer<T> chainConsumers(final Consumer<T> currentConsumer, final Consumer<T> consumer) {
         if (currentConsumer != null) {
             return currentConsumer.andThen(consumer);
         }
@@ -904,7 +904,7 @@ public abstract class SipMessageBuilder<T extends SipMessage> implements SipMess
         return consumer;
     }
 
-    private <T, S> BiConsumer<T, S> chainConsumers(final BiConsumer<T, S> currentConsumer, final BiConsumer<T, S> consumer) {
+    private static <T, S> BiConsumer<T, S> chainConsumers(final BiConsumer<T, S> currentConsumer, final BiConsumer<T, S> consumer) {
         if (currentConsumer != null) {
             return currentConsumer.andThen(consumer);
         }

--- a/pkts-streams/src/main/java/io/pkts/streams/impl/BasicSipStream.java
+++ b/pkts-streams/src/main/java/io/pkts/streams/impl/BasicSipStream.java
@@ -175,7 +175,7 @@ public class BasicSipStream implements SipStream {
         return null;
     }
 
-    private SDP getSDPorNull(final SipPacket msg) throws SipParseException {
+    private static SDP getSDPorNull(final SipPacket msg) throws SipParseException {
         final Object content = msg.getContent();
         if (content instanceof SDP) {
             return (SDP) content;

--- a/pkts-streams/src/main/java/io/pkts/streams/impl/DefaultRtpStream.java
+++ b/pkts-streams/src/main/java/io/pkts/streams/impl/DefaultRtpStream.java
@@ -64,7 +64,7 @@ public final class DefaultRtpStream implements RtpStream {
      * command should take care of that and make sure that we merge things in the correct order so
      * therefore we dont care here...
      */
-    private void redrive() {
+    private static void redrive() {
         // TODO
         if (logger.isInfoEnabled()) {
             logger.info("Out-of-sequence event detected. Redriving all traffic.");

--- a/pkts-streams/src/main/java/io/pkts/streams/impl/SimpleCallStateMachine.java
+++ b/pkts-streams/src/main/java/io/pkts/streams/impl/SimpleCallStateMachine.java
@@ -378,7 +378,7 @@ public final class SimpleCallStateMachine {
      * @param status
      * @return
      */
-    private boolean isRejected(final int status) {
+    private static boolean isRejected(final int status) {
         return status == 401 || status == 403 || status == 404 || status == 407 || status == 480
                 || status == 486 || status == 603;
     }

--- a/pkts-streams/src/main/java/io/pkts/streams/impl/SipStreamHandler.java
+++ b/pkts-streams/src/main/java/io/pkts/streams/impl/SipStreamHandler.java
@@ -58,7 +58,7 @@ public class SipStreamHandler {
         this.framerManager = framerManager;
     }
 
-    private StreamId getStreamId(final SipPacket msg) throws SipParseException {
+    private static StreamId getStreamId(final SipPacket msg) throws SipParseException {
         try {
             return new BufferStreamId(msg.getCallIDHeader().getValue());
         } catch (final NullPointerException e) {
@@ -140,7 +140,7 @@ public class SipStreamHandler {
      * 
      * @param msg
      */
-    private void checkMessageForContent(final SipPacket msg) {
+    private static void checkMessageForContent(final SipPacket msg) {
         if (!msg.hasContent()) {
             return;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar
