### PR TITLE
General Code Improvement 1

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/ByteNotFoundException.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/ByteNotFoundException.java
@@ -3,6 +3,8 @@
  */
 package io.pkts.buffer;
 
+import java.util.Arrays;
+
 /**
  * Exception for readUntil-methods and the like
  * 
@@ -26,13 +28,13 @@ public class ByteNotFoundException extends BufferException {
     }
 
     public ByteNotFoundException(final byte... bytes) {
-        super("Unable to locate any of the bytes " + bytes);
+        super("Unable to locate any of the bytes " + Arrays.toString(bytes));
         this.bytes = bytes;
     }
 
     public ByteNotFoundException(final int maxBytes, final byte... bytes) {
         super("Gave up looking after reading " + maxBytes + " bytes. You asked me to find any of the following bytes: "
-                + bytes);
+                + Arrays.toString(bytes));
         this.bytes = bytes;
     }
 

--- a/pkts-core/src/main/java/com/google/polo/pairing/HexDump.java
+++ b/pkts-core/src/main/java/com/google/polo/pairing/HexDump.java
@@ -121,13 +121,13 @@ public class HexDump {
 
     private static int toByte(final char c) {
         if ((c >= '0') && (c <= '9')) {
-            return (c - '0');
+            return c - '0';
         }
         if ((c >= 'A') && (c <= 'F')) {
-            return ((c - 'A') + 10);
+            return (c - 'A') + 10;
         }
         if ((c >= 'a') && (c <= 'f')) {
-            return ((c - 'a') + 10);
+            return (c - 'a') + 10;
         }
 
         throw new RuntimeException("Invalid hex char '" + c + "'");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding
findbugs:DMI_INVOKING_TOSTRING_ON_ARRAY Correctness - Invocation of toString on an array

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck 
https://dev.eclipse.org/sonar/rules/show/findbugs:DMI_INVOKING_TOSTRING_ON_ARRAY

Please let me know if you have any questions.

Zeeshan Asghar