### PR TITLE
String literals should not be duplicated

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/AbstractBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/AbstractBuffer.java
@@ -11,9 +11,10 @@ import java.io.UnsupportedEncodingException;
  */
 public abstract class AbstractBuffer implements Buffer {
 
+    private static final String FOR_INPUT_STRING = "For input string: \"";
     private static final byte LF = '\n';
     private static final byte CR = '\r';
-
+    private static final String EMPTY_BUFFER_CANT_WRITE = "This is an empty buffer. Cant write to it";
     /**
      * From where we will continue reading
      */
@@ -342,19 +343,19 @@ public abstract class AbstractBuffer implements Buffer {
 
     @Override
     public void write(final byte b) throws IndexOutOfBoundsException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(EMPTY_BUFFER_CANT_WRITE);
     }
 
     @Override
     public void write(final String s) throws IndexOutOfBoundsException, WriteNotSupportedException,
             UnsupportedEncodingException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(EMPTY_BUFFER_CANT_WRITE);
     }
 
     @Override
     public void write(final String s, final String charset) throws IndexOutOfBoundsException,
             WriteNotSupportedException, UnsupportedEncodingException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(EMPTY_BUFFER_CANT_WRITE);
     }
 
     @Override
@@ -459,7 +460,7 @@ public abstract class AbstractBuffer implements Buffer {
             if (i < max) {
                 digit = Character.digit((char) getByte(i++), radix);
                 if (digit < 0) {
-                    throw new NumberFormatException("For input string: \"" + this + "\"");
+                    throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
                 } else {
                     result = -digit;
                 }
@@ -468,25 +469,25 @@ public abstract class AbstractBuffer implements Buffer {
                 // Accumulating negatively avoids surprises near MAX_VALUE
                 digit = Character.digit((char) getByte(i++), radix);
                 if (digit < 0) {
-                    throw new NumberFormatException("For input string: \"" + this + "\"");
+                    throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
                 }
                 if (result < multmin) {
-                    throw new NumberFormatException("For input string: \"" + this + "\"");
+                    throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
                 }
                 result *= radix;
                 if (result < limit + digit) {
-                    throw new NumberFormatException("For input string: \"" + this + "\"");
+                    throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
                 }
                 result -= digit;
             }
         } else {
-            throw new NumberFormatException("For input string: \"" + this + "\"");
+            throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
         }
         if (negative) {
             if (i > 1) {
                 return result;
             } else { /* Only got "-" */
-                throw new NumberFormatException("For input string: \"" + this + "\"");
+                throw new NumberFormatException(FOR_INPUT_STRING + this + "\"");
             }
         } else {
             return -result;

--- a/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
@@ -9,6 +9,9 @@ import java.util.Arrays;
  */
 public class BoundedInputStreamBuffer extends AbstractBuffer {
 
+    private static final String CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER = "Cannot write to an InputStreamBuffer";
+    private static final String NOT_IMPLEMENTED_JUST_YET = "Not implemented just yet";
+
     private final InputStream is;
 
     /**
@@ -474,42 +477,42 @@ public class BoundedInputStreamBuffer extends AbstractBuffer {
 
     @Override
     public void getBytes(final Buffer dst) {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void getBytes(final int index, final Buffer dst) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void setInt(final int index, final int value) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void write(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void write(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void writeAsString(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void writeAsString(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override

--- a/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
@@ -13,6 +13,9 @@ import java.io.UnsupportedEncodingException;
  */
 public class EmptyBuffer implements Buffer {
 
+    private static final String THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT = "This is an empty buffer. Cant write to it";
+    private static final String THIS_BUFFER_IS_EMPTY = "This buffer is empty";
+    private static final String NOT_ENOUGH_READABLE_BYTES = "Not enough readable bytes";
     private static final byte[] EMPTY = new byte[0];
 
     /**
@@ -30,7 +33,7 @@ public class EmptyBuffer implements Buffer {
         if (length == 0) {
             return this;
         }
-        throw new IndexOutOfBoundsException("Not enough readable bytes");
+        throw new IndexOutOfBoundsException(NOT_ENOUGH_READABLE_BYTES);
     }
 
     /**
@@ -38,12 +41,12 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public Buffer readLine() throws IOException {
-        throw new IndexOutOfBoundsException("Not enough readable bytes");
+        throw new IndexOutOfBoundsException(NOT_ENOUGH_READABLE_BYTES);
     }
 
     @Override
     public Buffer readUntilDoubleCRLF() throws IOException {
-        throw new IndexOutOfBoundsException("Not enough readable bytes");
+        throw new IndexOutOfBoundsException(NOT_ENOUGH_READABLE_BYTES);
     }
 
     /**
@@ -92,7 +95,7 @@ public class EmptyBuffer implements Buffer {
     @Override
     public Buffer slice(final int start, final int stop) {
         if (start != 0 && stop != 0) {
-            throw new IndexOutOfBoundsException("This buffer is empty");
+            throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
         }
         return this;
     }
@@ -103,7 +106,7 @@ public class EmptyBuffer implements Buffer {
     @Override
     public Buffer slice(final int stop) {
         if (stop != 0) {
-            throw new IndexOutOfBoundsException("This buffer is empty");
+            throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
         }
         return this;
     }
@@ -153,7 +156,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public byte getByte(final int index) throws IndexOutOfBoundsException, IOException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -161,7 +164,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public byte readByte() throws IndexOutOfBoundsException, IOException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -169,7 +172,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public long readUnsignedInt() throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -177,7 +180,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public int readInt() throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -185,7 +188,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public int getInt(final int index) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -193,7 +196,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public short getShort(final int index) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -201,7 +204,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public int readUnsignedShort() throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -209,7 +212,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public int getUnsignedShort(final int index) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -217,7 +220,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public short readShort() throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -225,7 +228,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public short readUnsignedByte() throws IndexOutOfBoundsException, IOException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -233,7 +236,7 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public short getUnsignedByte(final int index) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -249,17 +252,17 @@ public class EmptyBuffer implements Buffer {
      */
     @Override
     public void setByte(final int index, final byte value) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     @Override
     public void setUnsignedByte(final int index, final short value) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     @Override
     public void setUnsignedShort(final int index, final int value) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     /**
@@ -283,7 +286,7 @@ public class EmptyBuffer implements Buffer {
 
     @Override
     public byte peekByte() throws IndexOutOfBoundsException, IOException {
-        throw new IndexOutOfBoundsException("Not enough readable bytes");
+        throw new IndexOutOfBoundsException(NOT_ENOUGH_READABLE_BYTES);
     }
 
     @Override
@@ -313,38 +316,38 @@ public class EmptyBuffer implements Buffer {
 
     @Override
     public void write(final byte b) throws IndexOutOfBoundsException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void write(final String s) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void write(final String s, final String charset) throws IndexOutOfBoundsException,
     WriteNotSupportedException, UnsupportedEncodingException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void write(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void write(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void writeAsString(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
     public void writeAsString(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
+        throw new WriteNotSupportedException(THIS_IS_AN_EMPTY_BUFFER_CANT_WRITE_TO_IT);
     }
 
     @Override
@@ -402,7 +405,7 @@ public class EmptyBuffer implements Buffer {
 
     @Override
     public void setUnsignedInt(final int index, final long value) throws IndexOutOfBoundsException {
-        throw new IndexOutOfBoundsException("This buffer is empty");
+        throw new IndexOutOfBoundsException(THIS_BUFFER_IS_EMPTY);
     }
 
     @Override

--- a/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
@@ -14,6 +14,10 @@ import java.util.List;
  */
 public final class InputStreamBuffer extends AbstractBuffer {
 
+    private static final String CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER = "Cannot write to an InputStreamBuffer";
+
+    private static final String NOT_IMPLEMENTED_JUST_YET = "Not implemented just yet";
+
     private final InputStream is;
 
     /**
@@ -517,42 +521,42 @@ public final class InputStreamBuffer extends AbstractBuffer {
 
     @Override
     public void getBytes(final Buffer dst) {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void getBytes(final int index, final Buffer dst) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void setInt(final int index, final int value) throws IndexOutOfBoundsException {
-        throw new RuntimeException("Not implemented just yet");
+        throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 
     @Override
     public void write(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void write(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void writeAsString(final int value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override
     public void writeAsString(final long value) throws IndexOutOfBoundsException, WriteNotSupportedException {
-        throw new WriteNotSupportedException("Cannot write to an InputStreamBuffer");
+        throw new WriteNotSupportedException(CANNOT_WRITE_TO_AN_INPUT_STREAM_BUFFER);
     }
 
     @Override

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/SipMessage.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/SipMessage.java
@@ -38,6 +38,8 @@ import static io.pkts.packet.sip.impl.PreConditions.assertNotNull;
  */
 public interface SipMessage extends Cloneable {
 
+    public static final String UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION = "Unable to parse out the method due to underlying IOException";
+
     /**
      * The first line of a sip message, which is either a request or a response
      * line
@@ -363,7 +365,7 @@ public interface SipMessage extends Cloneable {
             return m.getByte(0) == 'I' && m.getByte(1) == 'N' && m.getByte(2) == 'V' && m.getByte(3) == 'I'
                     && m.getByte(4) == 'T' && m.getByte(5) == 'E';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -380,7 +382,7 @@ public interface SipMessage extends Cloneable {
             return m.getByte(0) == 'R' && m.getByte(1) == 'E' && m.getByte(2) == 'G' && m.getByte(3) == 'I'
                     && m.getByte(4) == 'S' && m.getByte(5) == 'T' && m.getByte(6) == 'E' && m.getByte(7) == 'R';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -397,7 +399,7 @@ public interface SipMessage extends Cloneable {
         try {
             return m.getByte(0) == 'B' && m.getByte(1) == 'Y' && m.getByte(2) == 'E';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -416,7 +418,7 @@ public interface SipMessage extends Cloneable {
         try {
             return m.getByte(0) == 'A' && m.getByte(1) == 'C' && m.getByte(2) == 'K';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -435,7 +437,7 @@ public interface SipMessage extends Cloneable {
             return m.getByte(0) == 'C' && m.getByte(1) == 'A' && m.getByte(2) == 'N' && m.getByte(3) == 'C'
                     && m.getByte(4) == 'E' && m.getByte(5) == 'L';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -455,7 +457,7 @@ public interface SipMessage extends Cloneable {
             return m.getByte(0) == 'O' && m.getByte(1) == 'P' && m.getByte(2) == 'T' && m.getByte(3) == 'I'
                     && m.getByte(4) == 'O' && m.getByte(5) == 'N' && m.getByte(6) == 'S';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -476,7 +478,7 @@ public interface SipMessage extends Cloneable {
             return m.getByte(0) == 'M' && m.getByte(1) == 'E' && m.getByte(2) == 'S' && m.getByte(3) == 'S'
                     && m.getByte(4) == 'A' && m.getByte(5) == 'G' && m.getByte(6) == 'E';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 
@@ -495,7 +497,7 @@ public interface SipMessage extends Cloneable {
         try {
             return m.getByte(0) == 'I' && m.getByte(1) == 'N' && m.getByte(2) == 'F' && m.getByte(3) == 'O';
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the method due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_METHOD_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
     }
 

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/CSeqHeader.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/CSeqHeader.java
@@ -19,6 +19,7 @@ import static io.pkts.packet.sip.impl.PreConditions.assertNotEmpty;
  */
 public interface CSeqHeader extends SipHeader {
 
+    public static final String METHOD_CANNOT_BE_NULL_OR_EMPTY = "Method cannot be null or empty";
     Buffer NAME = Buffers.wrap("CSeq");
 
     Buffer getMethod();
@@ -64,11 +65,11 @@ public interface CSeqHeader extends SipHeader {
     }
 
     static Builder withMethod(final Buffer method) {
-        return new Builder(assertNotEmpty(method, "Method cannot be null or empty"));
+        return new Builder(assertNotEmpty(method, METHOD_CANNOT_BE_NULL_OR_EMPTY));
     }
 
     static Builder withMethod(final String method) {
-        return new Builder(Buffers.wrap(assertNotEmpty(method, "Method cannot be null or empty")));
+        return new Builder(Buffers.wrap(assertNotEmpty(method, METHOD_CANNOT_BE_NULL_OR_EMPTY)));
     }
 
     class Builder implements SipHeader.Builder<CSeqHeader> {
@@ -98,13 +99,13 @@ public interface CSeqHeader extends SipHeader {
         }
 
         public Builder withMethod(final Buffer method) throws SipParseException {
-            assertNotEmpty(method, "Method cannot be null or empty");
+            assertNotEmpty(method, METHOD_CANNOT_BE_NULL_OR_EMPTY);
             this.method = method;
             return this;
         }
 
         public Builder withMethod(final String method) throws SipParseException {
-            this.method = Buffers.wrap(assertNotEmpty(method, "Method cannot be null or empty"));
+            this.method = Buffers.wrap(assertNotEmpty(method, METHOD_CANNOT_BE_NULL_OR_EMPTY));
             return this;
         }
 

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/SipHeader.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/SipHeader.java
@@ -59,6 +59,9 @@ import static io.pkts.packet.sip.impl.PreConditions.assertNotEmpty;
  */
 public interface SipHeader extends Cloneable {
 
+    public static final String CANNOT_CAST_HEADER_OF_TYPE = "Cannot cast header of type ";
+    public static final String UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION = "Unable to parse out the header name due to underlying IOException";
+
     /**
      * Get the name of the header
      * 
@@ -190,13 +193,13 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'f';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default FromHeader toFromHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + FromHeader.class.getName());
     }
 
@@ -209,13 +212,13 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 't';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default ToHeader toToHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ToHeader.class.getName());
     }
 
@@ -245,13 +248,13 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'm';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default ContactHeader toContactHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ContactHeader.class.getName());
     }
 
@@ -264,7 +267,7 @@ public interface SipHeader extends Cloneable {
                         && m.getByte(6) == 't';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
@@ -281,13 +284,13 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'i';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default CallIdHeader toCallIdHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + CallIdHeader.class.getName());
     }
 
@@ -299,7 +302,7 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'R' && m.getByte(1) == 'o' && m.getByte(2) == 'u'
                         && m.getByte(3) == 't' && m.getByte(4) == 'e';
             } catch (final IOException e) {
-                throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+                throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
             }
         }
         return false;
@@ -314,19 +317,19 @@ public interface SipHeader extends Cloneable {
                         && m.getByte(6) == '-' && m.getByte(7) == 'R' && m.getByte(8) == 'o'
                         && m.getByte(9) == 'u' && m.getByte(10) == 't' && m.getByte(11) == 'e';
             } catch (final IOException e) {
-                throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+                throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
             }
         }
         return false;
     }
 
     default RecordRouteHeader toRecordRouteHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + RecordRouteHeader.class.getName());
     }
 
     default RouteHeader toRouteHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + RouteHeader.class.getName());
     }
 
@@ -344,13 +347,13 @@ public interface SipHeader extends Cloneable {
 
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default ContentLengthHeader toContentLengthHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ContentLengthHeader.class.getName());
     }
 
@@ -366,13 +369,13 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'c';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default ContentTypeHeader toContentTypeHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ContentTypeHeader.class.getName());
     }
 
@@ -385,13 +388,13 @@ public interface SipHeader extends Cloneable {
                         && m.getByte(6) == 's';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default ExpiresHeader toExpiresHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ExpiresHeader.class.getName());
     }
 
@@ -403,13 +406,13 @@ public interface SipHeader extends Cloneable {
                         && m.getByte(3) == 'q';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default CSeqHeader toCSeqHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + CSeqHeader.class.getName());
     }
 
@@ -422,14 +425,14 @@ public interface SipHeader extends Cloneable {
                         && m.getByte(6) == 'r' && m.getByte(7) == 'w' && m.getByte(8) == 'a'
                         && m.getByte(9) == 'r' && m.getByte(10) == 'd' && m.getByte(11) == 's';
             } catch (final IOException e) {
-                throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+                throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
             }
         }
         return false;
     }
 
     default ViaHeader toViaHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + ViaHeader.class.getName());
     }
 
@@ -443,18 +446,18 @@ public interface SipHeader extends Cloneable {
                 return m.getByte(0) == 'v';
             }
         } catch (final IOException e) {
-            throw new SipParseException(0, "Unable to parse out the header name due to underlying IOException", e);
+            throw new SipParseException(0, UNABLE_TO_PARSE_OUT_THE_HEADER_NAME_DUE_TO_UNDERLYING_IO_EXCEPTION, e);
         }
         return false;
     }
 
     default MaxForwardsHeader toMaxForwardsHeader() {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + MaxForwardsHeader.class.getName());
     }
 
     default AddressParametersHeader toAddressParametersHeader() throws ClassCastException {
-        throw new ClassCastException("Cannot cast header of type " + getClass().getName()
+        throw new ClassCastException(CANNOT_CAST_HEADER_OF_TYPE + getClass().getName()
                 + " to type " + AddressParametersHeader.class.getName());
     }
 

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/ImmutableSipMessage.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/ImmutableSipMessage.java
@@ -30,6 +30,7 @@ import java.util.Optional;
  */
 public abstract class ImmutableSipMessage implements SipMessage {
 
+    private static final String I_AM_IMMUTABLE_NO_CAN_DO = "I am immutable, no can do";
     private final Buffer message;
     private final SipInitialLine initialLine;
     private final List<SipHeader> headers;
@@ -155,23 +156,23 @@ public abstract class ImmutableSipMessage implements SipMessage {
 
     @Override
     public void addHeader(final SipHeader header) throws SipParseException {
-        throw new RuntimeException("I am immutable, no can do");
+        throw new RuntimeException(I_AM_IMMUTABLE_NO_CAN_DO);
     }
 
     @Override
     public void addHeaderFirst(SipHeader header) throws SipParseException {
-        throw new RuntimeException("I am immutable, no can do");
+        throw new RuntimeException(I_AM_IMMUTABLE_NO_CAN_DO);
 
     }
 
     @Override
     public SipHeader popHeader(Buffer headerNme) throws SipParseException {
-        throw new RuntimeException("I am immutable, no can do");
+        throw new RuntimeException(I_AM_IMMUTABLE_NO_CAN_DO);
     }
 
     @Override
     public void setHeader(SipHeader header) throws SipParseException {
-        throw new RuntimeException("I am immutable, no can do");
+        throw new RuntimeException(I_AM_IMMUTABLE_NO_CAN_DO);
 
     }
 

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
@@ -54,6 +54,8 @@ import java.util.function.Function;
  */
 public class SipParser {
 
+    private static final String UNABLE_TO_READ_FROM_STREAM = "Unable to read from stream";
+
     /**
      * There are many situations where you are looking to frame something but
      * you cannot find the terminating condition. Since an attacker could easily
@@ -544,7 +546,7 @@ public class SipParser {
             }
             return consumed;
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 
@@ -610,7 +612,7 @@ public class SipParser {
                         "Expected WS but nothing more to read in the buffer");
             }
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
         return consumed;
     }
@@ -1646,7 +1648,7 @@ public class SipParser {
         } catch (final IndexOutOfBoundsException e) {
             // fall through
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
         buffer.resetReaderIndex();
         return 0;
@@ -1693,7 +1695,7 @@ public class SipParser {
             }
             return count;
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 
@@ -1715,7 +1717,7 @@ public class SipParser {
                 throw new SipParseException(buffer.getReaderIndex(), "Expected '" + ch + "' got '" + i + "'");
             }
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 
@@ -1741,7 +1743,7 @@ public class SipParser {
             expectHCOLON(buffer);
             return name;
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 
@@ -1772,7 +1774,7 @@ public class SipParser {
             }
             return headers;
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 
@@ -1976,7 +1978,7 @@ public class SipParser {
 
             return new SipHeaderImpl(name, valueBuffer);
         } catch (final IOException e) {
-            throw new SipParseException(buffer.getReaderIndex(), "Unable to read from stream", e);
+            throw new SipParseException(buffer.getReaderIndex(), UNABLE_TO_READ_FROM_STREAM, e);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 String literals should not be duplicated
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
Zeeshan Asghar