### PR TITLE
Classes and methods that rely on the default system encoding should not be used

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/Buffers.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/Buffers.java
@@ -4,6 +4,7 @@
 package io.pkts.buffer;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -76,7 +77,7 @@ public final class Buffers {
             return Buffers.EMPTY_BUFFER;
         }
 
-        return Buffers.wrap(s.getBytes());
+        return Buffers.wrap(s.getBytes(Charset.forName("UTF-8")));
     }
 
     public static Buffer wrap(final InputStream is) {

--- a/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 /**
  * A buffer directly backed by a byte-array
@@ -290,8 +291,8 @@ public final class ByteBuffer extends AbstractBuffer {
                         // lazy! Fix this and also this won't really work
                         // for UTF-8 I believe. Def not for UTF-16 but good
                         // enough for now.
-                        final String s1 = new String(new byte[] {a1});
-                        final String s2 = new String(new byte[] {b1});
+                        final String s1 = new String(new byte[] {a1}, Charset.forName("UTF-8"));
+                        final String s2 = new String(new byte[] {b1}, Charset.forName("UTF-8"));
                         if (s1.equalsIgnoreCase(s2)) {
                             continue;
                         }

--- a/pkts-core/src/main/java/com/google/polo/pairing/HexDump.java
+++ b/pkts-core/src/main/java/com/google/polo/pairing/HexDump.java
@@ -16,6 +16,8 @@
 
 package com.google.polo.pairing;
 
+import java.nio.charset.Charset;
+
 public class HexDump {
     private final static char[] HEX_DIGITS = {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
@@ -39,7 +41,7 @@ public class HexDump {
 
                 for (int j = 0; j < 16; j++) {
                     if ((line[j] > ' ') && (line[j] < '~')) {
-                        result.append(new String(line, j, 1));
+                        result.append(new String(line, j, 1, Charset.forName("UTF-8")));
                     } else {
                         result.append(".");
                     }

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
@@ -23,6 +23,7 @@ import io.pkts.packet.sip.header.ViaHeader;
 import io.pkts.packet.sip.header.impl.SipHeaderImpl;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1666,7 +1667,7 @@ public class SipParser {
     public static void expect(final Buffer buffer, final byte expected) throws SipParseException, IOException {
         final byte actual = buffer.readByte();
         if (actual != expected) {
-            final String actualStr = new String(new byte[] { actual });
+            final String actualStr = new String(new byte[] { actual }, Charset.forName("UTF-8"));
             final String expectedStr = new String(new byte[] { expected });
             throw new SipParseException(buffer.getReaderIndex(), "Expected '" + expected + "' (" + expectedStr
                     + ") got '" + actual + "' (" + actualStr + ")");
@@ -1969,7 +1970,7 @@ public class SipParser {
                     for (final Buffer line : foldedLines) {
                         stupid += " " + line.toString();
                     }
-                    valueBuffer = Buffers.wrap(stupid.getBytes());
+                    valueBuffer = Buffers.wrap(stupid.getBytes(Charset.forName("UTF-8")));
                     consumeWS(valueBuffer);
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1943 Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943

Please let me know if you have any questions.

Zeeshan Asghar