### PR TITLE
User-friendly exception messages when parsing SIP URIs

### DIFF
--- a/pkts-sip/src/main/java/io/pkts/packet/sip/SipParseException.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/SipParseException.java
@@ -12,10 +12,12 @@ public class SipParseException extends SipException {
     private static final long serialVersionUID = 7627471115511100108L;
 
     private final int errorOffset;
+    private final String template;
 
     public SipParseException(final int errorOffset, final String message) {
-        super(message);
+        super(String.format(message, errorOffset));
         this.errorOffset = errorOffset;
+        this.template = message;
     }
 
     public SipParseException(final String message) {
@@ -23,12 +25,16 @@ public class SipParseException extends SipException {
     }
 
     public SipParseException(final int errorOffset, final String message, final Exception cause) {
-        super(message, cause);
+        super(String.format(message, errorOffset), cause);
         this.errorOffset = errorOffset;
+        this.template = message;
     }
 
     public int getErrorOffset() {
         return this.errorOffset;
     }
 
+    public String getTemplate() {
+        return template;
+    }
 }


### PR DESCRIPTION
Several small changes to improve the usefulness of error messages thrown during parsing a SIP URI.

In nearly every case, we are now able to provide a useful index to the character responsible for the error, giving developers and/or end users a meaningful indication of where they went wrong.

Notes:
* SipParseException was modified to take in a format string ("template") that is passed to String.format along with the "count" parameter.  This allows an outer method to re-throw a new exception with the same message but a different index that may be more relevant to the overall URI or SIP message being parsed.  For example, the user/host parser may throw an exception indicating an error on the second character in the user/host portion, but this would be the 6th char in the overall URI.
* SipURI.frame has been updated accordingly to catch the local errors thrown by methods such as expect() and consumeUserInfoHostPort() and re-throw new exceptions with more user-friendly messages.