### PR TITLE
Gracefully handles truncated SIP packets

### DIFF
--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
@@ -2072,7 +2072,7 @@ public class SipParser {
         // final Buffer headers = buffer.slice(startHeaders, buffer.getReaderIndex());
         Buffer payload = null;
         if (contentLength > 0 && buffer.hasReadableBytes()) {
-            payload = buffer.readBytes(contentLength);
+            payload = buffer.readBytes(Math.min(contentLength, buffer.getReadableBytes()));
         } else {
             payload = Buffers.EMPTY_BUFFER;
         }

--- a/pkts-sip/src/test/java/io/pkts/packet/sip/SipRequestTest.java
+++ b/pkts-sip/src/test/java/io/pkts/packet/sip/SipRequestTest.java
@@ -371,4 +371,18 @@ public class SipRequestTest extends PktsTestBase {
 
     }
 
+    /**
+     * Tests that the parser handles a packet that's prematurely truncated.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTruncatedPacket() throws Exception {
+        final int truncatedLength = RawData.sipInvite.length - 16;
+        final byte[] truncatedPacket = new byte[truncatedLength];
+        System.arraycopy(RawData.sipInvite, 0, truncatedPacket, 0, truncatedLength);
+        final SipRequest req = (SipRequest) parseMessage(truncatedPacket);
+        assertThat(req.toString().contains("o=user1 53655765 2353687637 IN IP4 127.0.1.1"), is(true));
+    }
+
 }


### PR DESCRIPTION
For SIP packets that are truncated and have their message bodies
cut off before content-length is reached, read what's available
and continue processing rather than throwing an exception.