### PR TITLE
Fix bug in BoundedInputStreamBuffer

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
@@ -93,7 +93,7 @@ public class BoundedInputStreamBuffer extends AbstractBuffer {
     public Buffer readBytes(final int length) throws IndexOutOfBoundsException, IOException {
         if (!checkReadableBytesSafe(length)) {
             final int availableBytes = getReadableBytes();
-            final int read = internalReadBytes(length - availableBytes);
+            final int read = internalReadBytes(length);
             if (read == -1) {
                 // end-of-file
                 return null;
@@ -122,12 +122,11 @@ public class BoundedInputStreamBuffer extends AbstractBuffer {
     }
 
     /**
-     * Read at most <code>length</code> no of bytes and store it into the
-     * internal buffer. This method is blocking in case we don't have enough
-     * bytes to read
+     * Ensure that <code>length</code> more bytes are available in the internal
+     * buffer. Read more bytes from the underlying stream if needed. This
+     * method is blocking in case we don't have enough bytes to read.
      *
-     * @param length
-     *            the amount of bytes we wishes to read
+     * @param length the amount of bytes we wishes to read
      * @return the actual number of bytes read.
      * @throws IOException
      */
@@ -139,7 +138,7 @@ public class BoundedInputStreamBuffer extends AbstractBuffer {
             return length;
         }
 
-        return readFromStream(length);
+        return readFromStream(length - getReadableBytes());
 
     }
 

--- a/pkts-buffers/src/test/java/io/pkts/buffer/BoundedInputStreamBufferTest.java
+++ b/pkts-buffers/src/test/java/io/pkts/buffer/BoundedInputStreamBufferTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -114,6 +115,20 @@ public class BoundedInputStreamBufferTest extends AbstractBufferTest {
             // expected
         }
 
+    }
+
+    /**
+     * Check that the buffer correctly reads more bytes from the underlying stream when they're needed.
+     */
+    @Test
+    public void testReadingOnDemand() throws Exception {
+        final byte[] content = RawData.rawEthernetFrame;
+        final InputStream in = new ByteArrayInputStream(content);
+        final Buffer outer = Buffers.wrap(in);
+        final Buffer first = outer.readBytes(50);
+        final Buffer second = outer.readBytes(150);
+        assertContent(first, content, 0);
+        assertContent(second, content, 50);
     }
 
     /**


### PR DESCRIPTION
Found a flaw where reading a second time resulted in empty bytes