### PR TITLE
Recognize ARP packets as valid Ethernet packets

### DIFF
--- a/pkts-core/src/main/java/io/pkts/framer/EthernetFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/EthernetFramer.java
@@ -70,10 +70,10 @@ public class EthernetFramer implements Framer<PCapPacket> {
     }
 
     public static EtherType getEtherTypeSafe(final byte b1, final byte b2) {
-        if (b1 == (byte) 0x08 && b2 == (byte) 0x00) {
-            return EtherType.IPv4;
-        } else if (b1 == (byte) 0x86 && b2 == (byte) 0xdd) {
-            return EtherType.IPv6;
+        for (EtherType t: EtherType.values()) {
+          if (b1 == t.b1 && b2 == t.b2) {
+              return t;
+          }
         }
 
         return null;
@@ -85,7 +85,7 @@ public class EthernetFramer implements Framer<PCapPacket> {
     }
 
     public static enum EtherType {
-        IPv4((byte) 0x08, (byte) 0x00), IPv6((byte) 0x86, (byte) 0xdd);
+        IPv4((byte) 0x08, (byte) 0x00), IPv6((byte) 0x86, (byte) 0xdd), ARP((byte) 0x08, (byte) 0x06);
 
         private final byte b1;
         private final byte b2;

--- a/pkts-core/src/test/java/io/pkts/framer/EthernetFramerTest.java
+++ b/pkts-core/src/test/java/io/pkts/framer/EthernetFramerTest.java
@@ -5,9 +5,13 @@ package io.pkts.framer;
 
 import io.pkts.PktsTestBase;
 
+import io.pkts.buffer.Buffer;
+import io.pkts.packet.PCapPacket;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -40,4 +44,14 @@ public class EthernetFramerTest extends PktsTestBase {
         this.framer.frame(null, this.ethernetFrameBuffer);
     }
 
+    @Test
+    public void testAcceptsAllEtherTypes() throws Exception {
+        for (EthernetFramer.EtherType t : EthernetFramer.EtherType.values()) {
+            Buffer frame = this.ethernetFrameBuffer.slice();
+            frame.setByte(12, t.b1);
+            frame.setByte(13, t.b2);
+            PCapPacket parent = mock(PCapPacket.class);
+            this.framer.frame(parent, frame);
+        }
+    }
 }


### PR DESCRIPTION
I really should support even more EtherTypes here, but we need to implement framer dispatch for IPv4 vs. IPv6 first, anyway.

I'm parsing some pcaps from my own LAN, and if I don't recognize ARP, then parsing the captures errors out.