### PR TITLE
Introduce FramingException for better handling of framing errors

### DIFF
--- a/pkts-core/src/main/java/io/pkts/Pcap.java
+++ b/pkts-core/src/main/java/io/pkts/Pcap.java
@@ -8,6 +8,7 @@ import io.pkts.filters.FilterFactory;
 import io.pkts.filters.FilterParseException;
 import io.pkts.frame.PcapGlobalHeader;
 import io.pkts.framer.FramerManager;
+import io.pkts.framer.FramingException;
 import io.pkts.framer.PcapFramer;
 import io.pkts.packet.Packet;
 
@@ -67,7 +68,7 @@ public class Pcap {
         }
     }
 
-    public void loop(final PacketHandler callback) throws IOException {
+    public void loop(final PacketHandler callback) throws IOException, FramingException {
         final ByteOrder byteOrder = this.header.getByteOrder();
         final PcapFramer framer = new PcapFramer(this.header, this.framerManager);
         int count = 1;

--- a/pkts-core/src/main/java/io/pkts/framer/Framer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/Framer.java
@@ -35,8 +35,10 @@ public interface Framer<T extends Packet> {
      * @throws IOException
      *             in case something goes wrong when reading data from the
      *             buffer
+     * @throws FramingException
+     *             in case the data in buffer can't be parsed by the framer
      */
-    T frame(T parent, Buffer buffer) throws IOException;
+    T frame(T parent, Buffer buffer) throws IOException, FramingException;
 
     /**
      * Check whether the supplied data could be framed into a frame of this

--- a/pkts-core/src/main/java/io/pkts/framer/FramingException.java
+++ b/pkts-core/src/main/java/io/pkts/framer/FramingException.java
@@ -1,0 +1,16 @@
+package io.pkts.framer;
+
+import io.pkts.protocol.Protocol;
+
+public class FramingException extends Exception {
+  private final Protocol protocol;
+
+  FramingException(String message, Protocol protocol) {
+    super(message);
+    this.protocol = protocol;
+  }
+
+  public Protocol getProtocol() {
+    return protocol;
+  }
+}

--- a/pkts-core/src/main/java/io/pkts/packet/Packet.java
+++ b/pkts-core/src/main/java/io/pkts/packet/Packet.java
@@ -117,8 +117,10 @@ public interface Packet extends Cloneable {
      * @throws IOException
      *             in case something goes wrong when framing the rest of the
      *             protocol stack
+     * @throws PacketParseException if the next packet can't be parsed by the
+     *                              framer
      */
-    Packet getPacket(Protocol p) throws IOException;
+    Packet getPacket(Protocol p) throws IOException, PacketParseException;
 
     /**
      * Get the name of the packet. Wireshark will give you a short description
@@ -138,8 +140,10 @@ public interface Packet extends Cloneable {
      * 
      * @return
      * @throws IOException
+     * @throws PacketParseException if the next packet can't be parsed by the
+     *                              framer
      */
-    Packet getNextPacket() throws IOException;
+    Packet getNextPacket() throws IOException, PacketParseException;
 
     /**
      * Almost all packets have a parent, which is the encapsulating protocol.

--- a/pkts-core/src/main/java/io/pkts/packet/impl/AbstractPacket.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/AbstractPacket.java
@@ -6,6 +6,7 @@ package io.pkts.packet.impl;
 import io.pkts.buffer.Buffer;
 import io.pkts.packet.IPPacket;
 import io.pkts.packet.Packet;
+import io.pkts.packet.PacketParseException;
 import io.pkts.packet.TransportPacket;
 import io.pkts.packet.UDPPacket;
 import io.pkts.packet.sip.SipPacket;
@@ -134,7 +135,7 @@ public abstract class AbstractPacket implements Packet {
      * @see io.pkts.packet.Packet#getPacket(io.pkts.protocol.Protocol)
      */
     @Override
-    public Packet getPacket(final Protocol p) throws IOException {
+    public Packet getPacket(final Protocol p) throws IOException, PacketParseException {
         if (this.protocol == p) {
             return this;
         }

--- a/pkts-core/src/main/java/io/pkts/packet/impl/PCapPacketImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/PCapPacketImpl.java
@@ -7,10 +7,11 @@ import io.pkts.buffer.Buffer;
 import io.pkts.frame.PcapGlobalHeader;
 import io.pkts.frame.PcapRecordHeader;
 import io.pkts.framer.EthernetFramer;
+import io.pkts.framer.FramingException;
 import io.pkts.framer.IPv4Framer;
 import io.pkts.framer.SllFramer;
-import io.pkts.packet.MACPacket;
 import io.pkts.packet.PCapPacket;
+import io.pkts.packet.PacketParseException;
 import io.pkts.protocol.Protocol;
 
 import java.io.IOException;
@@ -107,7 +108,7 @@ public final class PCapPacketImpl extends AbstractPacket implements PCapPacket {
     }
 
     @Override
-    public PCapPacket getNextPacket() throws IOException {
+    public PCapPacket getNextPacket() throws IOException, PacketParseException {
         final Buffer payload = getPayload();
         if (payload == null) {
             return null;
@@ -117,7 +118,11 @@ public final class PCapPacketImpl extends AbstractPacket implements PCapPacket {
         {
             case 1:
             default:
-                return ethernetFramer.frame(this, payload);
+                try {
+                    return ethernetFramer.frame(this, payload);
+                } catch (FramingException e) {
+                    throw new PacketParseException(16, "Ethernet parsing failed", e);
+                }
             case 113:
                 return sllFramer.frame(this, payload);
             case 101:

--- a/pkts-core/src/test/java/io/pkts/framer/PcapFramerTest.java
+++ b/pkts-core/src/test/java/io/pkts/framer/PcapFramerTest.java
@@ -76,7 +76,7 @@ public class PcapFramerTest extends PktsTestBase {
     }
 
     private void verifyNextFrame(final Buffer in, final int expectedLength)
-            throws IOException {
+            throws IOException, FramingException {
         final PCapPacket frame = this.framer.frame(null, in);
         final Buffer payload = frame.getPayload();
         assertThat(expectedLength, is(payload.capacity()));

--- a/pkts-examples/src/main/java/io/pkts/examples/core/CoreExample001.java
+++ b/pkts-examples/src/main/java/io/pkts/examples/core/CoreExample001.java
@@ -5,6 +5,7 @@ package io.pkts.examples.core;
 
 import io.pkts.PacketHandler;
 import io.pkts.Pcap;
+import io.pkts.framer.FramingException;
 import io.pkts.packet.Packet;
 import io.pkts.protocol.Protocol;
 
@@ -18,7 +19,7 @@ import java.io.IOException;
  */
 public class CoreExample001 {
 
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) throws IOException, FramingException {
 
         // Step 1 - obtain a new Pcap instance by supplying an InputStream that points
         //          to a source that contains your captured traffic. Typically you may

--- a/pkts-examples/src/main/java/io/pkts/examples/core/CoreExample002.java
+++ b/pkts-examples/src/main/java/io/pkts/examples/core/CoreExample002.java
@@ -3,6 +3,7 @@ package io.pkts.examples.core;
 import io.pkts.PacketHandler;
 import io.pkts.Pcap;
 import io.pkts.PcapOutputStream;
+import io.pkts.framer.FramingException;
 import io.pkts.packet.Packet;
 import io.pkts.packet.UDPPacket;
 import io.pkts.packet.sip.SipPacket;
@@ -28,7 +29,7 @@ import java.util.List;
  */
 public class CoreExample002 {
 
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) throws IOException, FramingException {
 
         // Step 1 - accept two inputs, first one being the pcap from which we will read
         //          and the second argument being the SIP Call-ID we are looking for.

--- a/pkts-examples/src/main/java/io/pkts/examples/streams/StreamsExample001.java
+++ b/pkts-examples/src/main/java/io/pkts/examples/streams/StreamsExample001.java
@@ -5,6 +5,7 @@ package io.pkts.examples.streams;
 
 import io.pkts.Pcap;
 import io.pkts.packet.sip.SipPacket;
+import io.pkts.framer.FramingException;
 import io.pkts.streams.SipStream;
 import io.pkts.streams.Stream;
 import io.pkts.streams.StreamHandler;
@@ -36,7 +37,7 @@ import java.io.IOException;
  */
 public final class StreamsExample001 {
 
-    public static void main(final String[] args) throws FileNotFoundException, IOException {
+    public static void main(final String[] args) throws FileNotFoundException, IOException, FramingException {
 
         // Step 1 - Open the pcap containing our traffic.
         final Pcap pcap = Pcap.openStream("my_traffic.pcap");


### PR DESCRIPTION
I'm in the process of implementing a tool that needs to be able to seek to arbitrary points in a pcap file in O(1) time, which means I have to depend on the framers to find the next valid packet at a particular point. To that end, I've been adding a bunch of frame validation code, and I wound up adding a new exception type to facilitate checking for framing errors. This patch is just the initial type changes and a teensy bit of validation, so that we can discuss whether this is the right way forward.

I'm looking for feedback on whether this is a good thing and what alternatives might be better. The first thing that comes to mind for me is fleshing out the accept() methods, instead of adding a new exception, but the raw RuntimeException in EthernetFramer made me think this is worthwhile.