### PR TITLE
Fixing issues around continuous streaming of (large) pcap data

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
@@ -244,11 +244,9 @@ public final class InputStreamBuffer extends AbstractBuffer {
             final int readAtMost = Math.min(length - total, spaceLeft);
 
             final java.nio.ByteBuffer bb = getWritingRow();
-            try {
-                actual = this.is.read(bb.array(), localIndex, readAtMost);
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
+
+            actual = this.is.read(bb.array(), localIndex, readAtMost);
+
             if (actual > 0) {
                 this.upperBoundary += actual;
                 this.writerIndex = this.upperBoundary;

--- a/pkts-core/src/main/java/io/pkts/Pcap.java
+++ b/pkts-core/src/main/java/io/pkts/Pcap.java
@@ -1,5 +1,6 @@
 package io.pkts;
 
+import io.pkts.buffer.BoundedInputStreamBuffer;
 import io.pkts.buffer.Buffer;
 import io.pkts.buffer.Buffers;
 import io.pkts.filters.Filter;
@@ -118,6 +119,20 @@ public class Pcap {
      */
     public static Pcap openStream(final InputStream is) throws IOException {
         final Buffer stream = Buffers.wrap(is);
+        final PcapGlobalHeader header = PcapGlobalHeader.parse(stream);
+        return new Pcap(header, stream);
+    }
+
+    /**
+     * Capture packets from the input stream
+     *
+     * @param is
+     * @param bufferCapacity Size of buffer, must be larger than PCAPs largest framesize. See SNAPLENGTH for tcpdump, et.al.
+     * @return
+     * @throws IOException
+     */
+    public static Pcap openStream(final InputStream is, final int bufferCapacity) throws IOException {
+        final Buffer stream = new BoundedInputStreamBuffer(bufferCapacity, is);
         final PcapGlobalHeader header = PcapGlobalHeader.parse(stream);
         return new Pcap(header, stream);
     }


### PR DESCRIPTION
 - Unexpected end-of-stream exception would cause endless loop.
 - BoundedInputStreamBuffer had a 2gb limit on PCAP stream. Fixed by changing from 32bit to 64bit indexes.
 - BoundedInputStreamBuffer had an incorrect slice function. Code added but commented out as nobody uses these function.
 - BoundedInputStreamBuffer had various unimplemented/unused methods, changed them all to throw not-implemented-exceptions.
 - BoundedInputStreamBuffer had a cyclic buffer that is smaller than default snaplength in tcpdump, causing errors with packets automatically defragmented by hardware (LRO/GRO).
 - Allow clients of Pcap.java to decide on buffer size in BoundedInputStreamBuffer, to match what snaplength was used during capture, as new default is quite large (256kb).