### PR TITLE
Fix calculation of IPv4 header length

### DIFF
--- a/pkts-core/src/main/java/io/pkts/packet/impl/IPv4PacketImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/IPv4PacketImpl.java
@@ -287,7 +287,8 @@ public final class IPv4PacketImpl extends AbstractPacket implements IPv4Packet {
     public int getHeaderLength() {
         try {
             final byte b = this.headers.getByte(0);
-            return b & 0x0F;
+            // length is encoded as the number of 32-bit words, so to get number of bytes we must multiply by 4
+            return (b & 0x0F) * 4;
         } catch (final IOException e) {
             throw new RuntimeException("unable to get the header length of the IP packet due to IOException", e);
         }

--- a/pkts-core/src/test/java/io/pkts/packet/impl/IPv4PacketImplTest.java
+++ b/pkts-core/src/test/java/io/pkts/packet/impl/IPv4PacketImplTest.java
@@ -141,4 +141,12 @@ public class IPv4PacketImplTest extends PktsTestBase {
         pkt.setSourceIP("55.66.77.88");
         assertThat(pkt.getSourceIP(), is("55.66.77.88"));
     }
+
+    @Test
+    public void testHeaderLength() throws Exception {
+        final IPv4Packet pkt = loadIPPackets("sipp.pcap").get(0);
+        // normal IP header is 5 32-bit words, or 20 bytes long
+        assertThat(pkt.getHeaderLength(), is(20));
+
+    }
 }


### PR DESCRIPTION
Previously it was documented as returning the header length in bytes, but it actually returned the header length in 32-bit words.