### PR TITLE
Throw PacketParseException instead of RuntimeException when IPv4 encounters a next protocol it can't handle

### DIFF
--- a/pkts-core/src/main/java/io/pkts/packet/impl/IPv4PacketImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/IPv4PacketImpl.java
@@ -10,6 +10,7 @@ import io.pkts.framer.UDPFramer;
 import io.pkts.packet.IPv4Packet;
 import io.pkts.packet.PCapPacket;
 import io.pkts.packet.Packet;
+import io.pkts.packet.PacketParseException;
 import io.pkts.protocol.Protocol;
 
 import java.io.IOException;
@@ -257,15 +258,18 @@ public final class IPv4PacketImpl extends AbstractPacket implements IPv4Packet {
         // the protocol is in byte 10
         final byte code = this.headers.getByte(9);
         final Protocol protocol = Protocol.valueOf(code);
-        switch (protocol) {
-        case UDP:
-            return udpFramer.frame(this, payload);
-        case TCP:
-            return tcpFramer.frame(this, payload);
-        default:
-            throw new RuntimeException("Unknown Protocol. Was this SCTP or something???");
+        if (protocol != null) {
+            switch (protocol) {
+            case UDP:
+                return udpFramer.frame(this, payload);
+            case TCP:
+                return tcpFramer.frame(this, payload);
+            default:
+                throw new PacketParseException(9, String.format("Unsupported inner protocol %s for IPv4", protocol.getName()));
+            }
+        } else {
+            throw new PacketParseException(9, String.format("Unknown protocol %d inside IPv4 packet", code));
         }
-
     }
 
     /**

--- a/pkts-core/src/main/java/io/pkts/packet/impl/IPv6PacketImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/impl/IPv6PacketImpl.java
@@ -164,10 +164,10 @@ public final class IPv6PacketImpl extends AbstractPacket implements IPv6Packet {
             case TCP:
                 return tcpFramer.frame(this, payload);
             default:
-                throw new PacketParseException(0, "Unsupported inner protocol");
+                throw new PacketParseException(0, "Unsupported inner protocol for IPv6");
             }
         } else {
-            throw new PacketParseException(0, "Unknown Protocol. Was this SCTP or something???");
+            throw new PacketParseException(0, String.format("Unknown protocol %d inside IPv6 packet", nextProtocol));
         }
 
     }


### PR DESCRIPTION
This enables callers to catch PacketParseException explicitly.