### PR TITLE
Ensure a valid PCAP length before trying to frame it

### DIFF
--- a/pkts-core/src/main/java/io/pkts/framer/PcapFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/PcapFramer.java
@@ -59,6 +59,9 @@ public final class PcapFramer implements Framer<Packet, PCapPacket> {
 
         final PcapRecordHeader header = new PcapRecordHeader(this.byteOrder, record);
         final int length = (int) header.getCapturedLength();
+        if (length < 0) {
+            throw new FramingException(String.format("Invalid PCAP captured length of %d", length), Protocol.PCAP);
+        }
         final int total = (int) header.getTotalLength();
         final Buffer payload = buffer.readBytes(Math.min(length, total));
         return new PCapPacketImpl(globalHeader, header, payload);


### PR DESCRIPTION
While I was working on `ChannelBuffer`, I wound up catching a bug during decoding thanks to length being negative. This is a reasonable thing to check in general as a minimal sanity check of a PCAP header.