### PR TITLE
Fix typo in method name `Buffer#getByes(byte[])`

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/BoundedInputStreamBuffer.java
@@ -508,7 +508,7 @@ public class BoundedInputStreamBuffer extends BaseBuffer {
     }
 
     @Override
-    public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
+    public void getBytes(final byte[] dst) throws IndexOutOfBoundsException {
         throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 

--- a/pkts-buffers/src/main/java/io/pkts/buffer/Buffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/Buffer.java
@@ -40,7 +40,16 @@ public interface Buffer extends Cloneable {
      */
     void getBytes(final int index, final Buffer dst) throws IndexOutOfBoundsException;
 
-    void getByes(final byte[] dst) throws IndexOutOfBoundsException;
+    void getBytes(final byte[] dst) throws IndexOutOfBoundsException;
+
+    /**
+     * @see #getBytes(byte[])
+     * @deprecated Please use {@link #getBytes(byte[])} instead
+     */
+    @Deprecated
+    default void getByes(final byte[] dst) throws IndexOutOfBoundsException {
+        getBytes(dst);
+    }
 
     /**
      * Read the requested number of bytes and increase the readerIndex with the

--- a/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/ByteBuffer.java
@@ -376,7 +376,7 @@ public final class ByteBuffer extends AbstractBuffer {
     }
 
     @Override
-    public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
+    public void getBytes(final byte[] dst) throws IndexOutOfBoundsException {
         final int length = Math.min(dst.length, getReadableBytes());
         System.arraycopy(this.buffer, this.lowerBoundary + this.readerIndex, dst, 0, length);
     }

--- a/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
@@ -405,7 +405,7 @@ public class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
+    public void getBytes(final byte[] dst) throws IndexOutOfBoundsException {
         // since it is empty, there are no bytes to get
         // so therefore leaving empty.
     }

--- a/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/InputStreamBuffer.java
@@ -528,7 +528,7 @@ public final class InputStreamBuffer extends AbstractBuffer {
     }
 
     @Override
-    public void getByes(final byte[] dst) throws IndexOutOfBoundsException {
+    public void getBytes(final byte[] dst) throws IndexOutOfBoundsException {
         throw new RuntimeException(NOT_IMPLEMENTED_JUST_YET);
     }
 


### PR DESCRIPTION
The `Buffer#getByes(byte[])` method suffered from a typo. The method has been renamed
and a (deprecated) default implementation with the old name has been added which
delegates to the correctly spelled method, so that existing consumers of the misspelled
method don't break.