### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: java
+jdk:
+  - openjdk8
+  - oraclejdk8
+  - oraclejdk9


### PR DESCRIPTION
Travis CI seems to fail because there's no configuration file specifying the build environment.

This change set adds a `.travis.yml` file and runs tests on OpenJDK 8, Oracle JDK 8, and Oracle JDK 9.