### PR TITLE
Fixes 106 - Infinite loop for whitespace in param handling in URI

### DIFF
--- a/pkts-buffers/src/main/java/io/pkts/buffer/BaseBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/BaseBuffer.java
@@ -87,12 +87,13 @@ public abstract class BaseBuffer implements Buffer {
         }
 
         final int size = index - getReaderIndex();
-        Buffer result = null;
+        final Buffer result;
         if (size == 0) {
             result = Buffers.EMPTY_BUFFER;
         } else {
             result = readBytes(size);
         }
+
         readByte(); // consume the one at the index as well
         return result;
     }
@@ -263,9 +264,6 @@ public abstract class BaseBuffer implements Buffer {
      *
      * </blockquote>
      *
-     * @param s
-     *            the <code>String</code> containing the integer representation
-     *            to be parsed
      * @param radix
      *            the radix to be used while parsing <code>s</code>.
      * @return the integer represented by the string argument in the specified
@@ -293,8 +291,8 @@ public abstract class BaseBuffer implements Buffer {
         int i = getReaderIndex();
 
         final int max = getReadableBytes() + getReaderIndex();
-        int limit;
-        int multmin;
+        final int limit;
+        final int multmin;
         int digit;
 
         if (max > 0) {

--- a/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
+++ b/pkts-buffers/src/main/java/io/pkts/buffer/EmptyBuffer.java
@@ -343,7 +343,7 @@ public class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public void write(byte[] bytes) throws IndexOutOfBoundsException, WriteNotSupportedException {
+    public void write(final byte[] bytes) throws IndexOutOfBoundsException, WriteNotSupportedException {
         throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
     }
 
@@ -384,7 +384,7 @@ public class EmptyBuffer implements Buffer {
     }
 
     @Override
-    public void setWriterIndex(int index) {
+    public void setWriterIndex(final int index) {
         throw new WriteNotSupportedException("This is an empty buffer. Cant write to it");
     }
 
@@ -449,7 +449,7 @@ public class EmptyBuffer implements Buffer {
 
         try {
             return ((Buffer) other).isEmpty();
-        } catch (NullPointerException | ClassCastException e) {
+        } catch (final NullPointerException | ClassCastException e) {
             return false;
         }
     }

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/address/Address.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/address/Address.java
@@ -135,7 +135,7 @@ public interface Address {
                         "Unable to parse the uri (addr-spec) portion of the address");
             }
         } else {
-            addrSpec = SipParser.consumeAddressSpec(buffer);
+            addrSpec = SipParser.consumeAddressSpec(true, buffer);
         }
 
         if (addrSpec == null) {

--- a/pkts-sip/src/main/java/io/pkts/packet/sip/header/FromHeader.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/header/FromHeader.java
@@ -94,8 +94,8 @@ public interface FromHeader extends AddressParametersHeader {
 
     /**
      * Frame the value as a {@link FromHeader}.
-     * 
-     * @param value
+     *
+     * @param buffer
      * @return
      * @throws SipParseException in case anything goes wrong while parsing.
      */
@@ -103,6 +103,17 @@ public interface FromHeader extends AddressParametersHeader {
         final Buffer original = buffer.slice();
         final Object[] result = AddressParametersHeader.frame(buffer);
         return new FromHeaderImpl(original, (Address) result[0], (Buffer) result[1]);
+    }
+
+    /**
+     * Frame the value as a {@link FromHeader}.
+     *
+     * @param buffer
+     * @return
+     * @throws SipParseException in case anything goes wrong while parsing.
+     */
+    static FromHeader frame(final String buffer) throws SipParseException {
+        return frame(Buffers.wrap(buffer));
     }
 
     /**

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_001.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_001.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>;nope=no_tag
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_002.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_002.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_003.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_003.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: sip:blah@example.com
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_004.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_004.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: sip:blah@example.com;hello=world
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_005.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_005.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: sip:blah@example.com
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_006.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_006.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>                                   ;nope=no_tag
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_007.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_007.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>                                   ;nope
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_008.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_008.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com; transport = tcp>;nope
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_009.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_009.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com; transport = tcp>;
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_010.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_010.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>;asdf=
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_011.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_011.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>;tag
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+

--- a/pkts-sip/src/test/resources/io/pkts/issue-106_012.txt
+++ b/pkts-sip/src/test/resources/io/pkts/issue-106_012.txt
@@ -1,0 +1,14 @@
+SUBSCRIBE sip:whatever@example.com SIP/2.0
+Via: SIP/2.0/UDP 10.11.12.12:2048;rport;branch=asdf
+From: <sip:blah@example.com>;tag=
+To: <sip:nisse@example.com>
+Call-ID: 106887444@10.11.12.12
+CSeq: 1 SUBSCRIBE
+Event: ua-profile;profile-type="device";vendor="snom";model="snom320";version="8.7.5.35"
+Expires: 0
+Accept: application/url
+Contact: <sip:10.11.12.12:2048>
+User-Agent: snom320/8.7.5.35
+Content-Length: 0
+
+


### PR DESCRIPTION
According to specification, a name-addr is not allowed to have any white
space between the host and the parameter list like so:
`<sip:alice@example.com;       wrong=no_space_please>`. However, this does occur
in the "wild" and just "looking" at the address, it is clear that those
parameters should belong to the URI. Therefore, those extra spaces
should really be allowed so the fix is essentially relaxing the rules a
bit.

Then, even if the old rules were more strict, we shouldn't end up in a
loop. It is unclear exactly what the customer who reported the issue ran
into but ultimately, due to the above poor parsing, we ended up with a
ParametersSupport that had "bad values" it couldn't parse and got stuck
in an endless loop.

So, there were several contributing issues (it seems).
1. Poor parsing of the address-spec, which then exposed
2. a bug in ParametersSupport that could cause an infinite loop

This fix addresses both. More robust (relaxed) parsing and fix in the
ParametersSupport to detect and bail out if we are not making any
progress.