### PR TITLE
Update SipParser to allow for LF terminated SIP headers

### DIFF
--- a/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
+++ b/pkts-sip/src/main/java/io/pkts/packet/sip/impl/SipParser.java
@@ -1950,6 +1950,7 @@ public class SipParser {
         public int start;
         public int stop = -1;
         public boolean foundCR = false;
+        public boolean foundLF = false;
         public boolean foundCRLF = false;
         public boolean foundComma = false;
         public boolean insideQuotedString = false;
@@ -1965,6 +1966,7 @@ public class SipParser {
             values = new ArrayList<>(2);
             stop = -1;
             foundCR = false;
+            foundLF = false;
             foundCRLF = false;
             foundComma = false;
             insideQuotedString = false;
@@ -1982,8 +1984,10 @@ public class SipParser {
                     state.insideQuotedString = !state.insideQuotedString;
                     break;
                 case LF:
+                    state.foundLF = true;
                     state.foundCRLF = state.foundCR;
-                    state.stop = buffer.getReaderIndex() - 2;
+                    int separatorLen = (state.foundCRLF) ? 2 : 1;
+                    state.stop = buffer.getReaderIndex() - separatorLen;
                     break;
                 case CR:
                     state.foundCR = true;
@@ -2005,7 +2009,7 @@ public class SipParser {
                     break;
             }
 
-            if (state.foundCRLF) {
+            if (state.foundCRLF || state.foundLF) {
                 state.values.add(buffer.slice(state.start, state.stop));
                 // if (isNext(buffer, LF)) {
                 // buffer.readByte();
@@ -2028,6 +2032,7 @@ public class SipParser {
                 }
 
                 state.foundCR = false;
+                state.foundLF = false;
                 state.foundCRLF = false;
                 state.foundComma = false;
                 state.start = buffer.getReaderIndex();


### PR DESCRIPTION
In our production system we caught a pcap that had a `To:` SIP header separated from the `From:` header by `LF` character (0x0A) instead of the usual CRLF (0x0D0A) combination. This caused this library to end up in a sort-of an infinite loop that caused our service's CPU to be pegged, essentially rendering our service useless.

W're not sure `LF` separators are allowed, but in order to fix this issue we decided to update the SipParser to consider `LF` to be a valid separator of SIP headers. This PR shows the changes that we made.
