### PR TITLE
updated parseSipContent()

### DIFF
--- a/pkts-core/src/main/java/io/pkts/packet/sip/impl/SipPacketImpl.java
+++ b/pkts-core/src/main/java/io/pkts/packet/sip/impl/SipPacketImpl.java
@@ -431,7 +431,7 @@ public abstract class SipPacketImpl extends AbstractPacket implements SipPacket 
         try {
             final Buffer content = this.msg.getContent();
             final ContentTypeHeader contentType = getContentTypeHeader();
-            if (content != null && contentType.isSDP()) {
+              if (content != null && !content.isEmpty() && contentType.isSDP()) {
                 return SDPFactory.getInstance().parse(content);
             }
         } catch (final SipPacketParseException | SdpException e) {


### PR DESCRIPTION
When parsing large-scale pcap file, I have faced heap memory exception. After investigating problem, I found the bug and fixed it like this.