### PR TITLE
Add getter for the `Pcap` global header

### DIFF
--- a/pkts-core/src/main/java/io/pkts/Pcap.java
+++ b/pkts-core/src/main/java/io/pkts/Pcap.java
@@ -167,4 +167,10 @@ public class Pcap {
         // TODO
     }
 
+    /**
+     *
+     */
+    public PcapGlobalHeader getPcapHeader() {
+        return this.header;
+    }
 }


### PR DESCRIPTION
I hope that this fits with the design of the library.

Accessing the global header while processing a stream is required to know whether the captures use microsecond or nanosecond precision. I can also imagine that other use cases might require access to other fields such as the data link type.