### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pkts-buffers/pom.xml
+++ b/pkts-buffers/pom.xml
@@ -20,10 +20,7 @@
       <artifactId>junit</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
+    
 
   </dependencies>
 

--- a/pkts-examples/pom.xml
+++ b/pkts-examples/pom.xml
@@ -18,11 +18,7 @@
       <artifactId>pkts-streams</artifactId>
     </dependency>
 
-   <dependency> 
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-api</artifactId>
-     <scope>compile</scope>
-   </dependency>
+   
 
   </dependencies>
 

--- a/pkts-sdp/pom.xml
+++ b/pkts-sdp/pom.xml
@@ -34,15 +34,9 @@
 
 
     <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
+    
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
+    
 
   </dependencies>
 

--- a/pkts-sip/pom.xml
+++ b/pkts-sip/pom.xml
@@ -19,12 +19,7 @@
       <artifactId>pkts-buffers</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-sdp</artifactId>
-    </dependency>
-
-    <!-- Test Dependencies -->
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pkts-streams/pom.xml
+++ b/pkts-streams/pom.xml
@@ -35,18 +35,8 @@
       <artifactId>junit</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
-
-   <!-- Just so that we get out some logging 
-        when running the test cases -->
-   <dependency> 
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-log4j12</artifactId>
-     <scope>test</scope>
-   </dependency>
+    
+   
 
     <dependency>
        <groupId>log4j</groupId>

--- a/pkts-tools/pom.xml
+++ b/pkts-tools/pom.xml
@@ -20,21 +20,10 @@
     </dependency>
 
     <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
+    
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
-
-    <!-- Runtime Dependencies -->
-   <dependency> 
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-log4j12</artifactId>
-   </dependency>
+    
+   
 
     <dependency>
        <groupId>log4j</groupId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
pkts-parent
pkts-buffers
{groupId='org.mockito', artifactId='mockito-all'}
pkts-sdp
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-all'}
pkts-sip
{groupId='io.pkts', artifactId='pkts-sdp'}
pkts-core
pkts-streams
{groupId='org.mockito', artifactId='mockito-all'}
{groupId='org.slf4j', artifactId='slf4j-log4j12'}
pkts-examples
{groupId='org.slf4j', artifactId='slf4j-api'}
pkts-tools
{groupId='junit', artifactId='junit'}
{groupId='org.mockito', artifactId='mockito-all'}
{groupId='org.slf4j', artifactId='slf4j-log4j12'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
