### PR TITLE
Java 11 now minimum version, upgrading dependencies.

### DIFF
--- a/pkts-core/pom.xml
+++ b/pkts-core/pom.xml
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
   </dependencies>

--- a/pkts-sdp/pom.xml
+++ b/pkts-sdp/pom.xml
@@ -19,24 +19,19 @@
       <artifactId>pkts-buffers</artifactId>
     </dependency>
 
-   <!-- only for the SDP support. The reason
-        for including the entire jain sip ri
-        is because I couldn't find an official
-        SDP only release in any maven repos
-        and I didn't want to complicate things
-        for potential contributors so until
-        I write my own SDP library this will
-        be included. -->
+    <!-- only for the SDP support. The reason
+         for including the entire jain sip ri
+         is because I couldn't find an official
+         SDP only release in any maven repos
+         and I didn't want to complicate things
+         for potential contributors so until
+         I write my own SDP library this will
+         be included. -->
     <dependency>
-       <groupId>javax.sip</groupId>
-       <artifactId>jain-sip-ri</artifactId>
-   </dependency>
-
-
+      <groupId>javax.sip</groupId>
+      <artifactId>jain-sip-ri</artifactId>
+    </dependency>
     <!-- Test Dependencies -->
-    
-
-    
 
   </dependencies>
 

--- a/pkts-sip/pom.xml
+++ b/pkts-sip/pom.xml
@@ -27,7 +27,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
   </dependencies>

--- a/pkts-streams/pom.xml
+++ b/pkts-streams/pom.xml
@@ -35,9 +35,6 @@
       <artifactId>junit</artifactId>
     </dependency>
 
-    
-   
-
     <dependency>
        <groupId>log4j</groupId>
        <artifactId>log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,212 +1,236 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
-  <prerequisites>
-     <maven>3.0.4</maven>
-  </prerequisites>
+    <modelVersion>4.0.0</modelVersion>
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
 
-  <name>Pkts IO</name>
-  <groupId>io.pkts</groupId>
-  <artifactId>pkts-parent</artifactId>
-  <version>3.0.11-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <description>PKTS IO - A pure java based library for manipulating pcaps</description>
-  <licenses>
-     <license>
-       <name>MIT License</name>
-       <url>http://www.opensource.org/licenses/mit-license.php</url>
-       <distribution>repo</distribution>
-     </license>
-   </licenses>
+    <name>Pkts IO</name>
+    <groupId>io.pkts</groupId>
+    <artifactId>pkts-parent</artifactId>
+    <version>3.0.11-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <description>PKTS IO - A pure java based library for manipulating pcaps</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-   <developers>
-      <developer>
-         <name>Jonas Borjesson</name>
-         <email>jonas@jonasborjesson.com</email>
-         <timezone>-8</timezone>
-      </developer>
-   </developers>
+    <developers>
+        <developer>
+            <name>Jonas Borjesson</name>
+            <email>jonas@jonasborjesson.com</email>
+            <timezone>-8</timezone>
+        </developer>
+    </developers>
 
-  <scm>
-    <connection>scm:git:git@github.com:aboutsip/pkts.git</connection>
-    <developerConnection>scm:git:git@github.com:aboutsip/pkts.git</developerConnection>
-    <url>git@github.com:aboutsip/pkts.git</url>
-    <tag>HEAD</tag>
-  </scm>
+    <scm>
+        <connection>scm:git:git@github.com:aboutsip/pkts.git</connection>
+        <developerConnection>scm:git:git@github.com:aboutsip/pkts.git</developerConnection>
+        <url>git@github.com:aboutsip/pkts.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <netty.version>4.1.42.Final</netty.version>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <netty.version>4.1.42.Final</netty.version>
+    </properties>
 
-  <modules>
-    <module>pkts-buffers</module>
-    <module>pkts-sdp</module>
-    <module>pkts-sip</module>
-    <module>pkts-core</module>
-    <module>pkts-streams</module>
-    <module>pkts-examples</module>
-    <module>pkts-tools</module>
-  </modules>
+    <modules>
+        <module>pkts-buffers</module>
+        <module>pkts-sdp</module>
+        <module>pkts-sip</module>
+        <module>pkts-core</module>
+        <module>pkts-streams</module>
+        <module>pkts-examples</module>
+        <module>pkts-tools</module>
+    </modules>
 
-  <dependencyManagement>
-    <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.pkts</groupId>
+                <artifactId>pkts-buffers</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-buffers</artifactId>
-      <version>${project.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <dependency>
+                <groupId>io.pkts</groupId>
+                <artifactId>pkts-sdp</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-sdp</artifactId>
-      <version>${project.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <dependency>
+                <groupId>io.pkts</groupId>
+                <artifactId>pkts-sip</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-sip</artifactId>
-      <version>${project.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <dependency>
+                <groupId>io.pkts</groupId>
+                <artifactId>pkts-core</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-core</artifactId>
-      <version>${project.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <dependency>
+                <groupId>io.pkts</groupId>
+                <artifactId>pkts-streams</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>io.pkts</groupId>
-      <artifactId>pkts-streams</artifactId>
-      <version>${project.version}</version>
-      <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${netty.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-   <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>${netty.version}</version>
-       <type>jar</type>
-      <scope>compile</scope>
-    </dependency>
+            <!-- only for the SDP support. The reason
+                 for including the entire jain sip ri
+                 is because I couldn't find an official
+                 SDP only release in any maven repos
+                 and I didn't want to complicate things
+                 for potential contributors so until
+                 I write my own SDP library this will
+                 be included. -->
+            <dependency>
+                <groupId>javax.sip</groupId>
+                <artifactId>jain-sip-ri</artifactId>
+                <version>1.2.159</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
 
-   <!-- only for the SDP support. The reason
-        for including the entire jain sip ri
-        is because I couldn't find an official
-        SDP only release in any maven repos
-        and I didn't want to complicate things
-        for potential contributors so until
-        I write my own SDP library this will
-        be included. -->
-    <dependency>
-       <groupId>javax.sip</groupId>
-       <artifactId>jain-sip-ri</artifactId>
-       <version>1.2.159</version>
-       <type>jar</type>
-       <scope>compile</scope>
-   </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.2</version>
+                <scope>provided</scope>
+            </dependency>
 
-   <dependency> 
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-api</artifactId>
-     <version>1.7.2</version>
-     <scope>provided</scope>
-   </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.2</version>
+                <scope>runtime</scope>
+            </dependency>
 
-   <dependency> 
-     <groupId>org.slf4j</groupId>
-     <artifactId>slf4j-log4j12</artifactId>
-     <version>1.7.2</version>
-     <scope>runtime</scope>
-   </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+                <scope>runtime</scope>
+            </dependency>
 
-    <dependency>
-       <groupId>log4j</groupId>
-       <artifactId>log4j</artifactId>
-       <version>1.2.14</version>
-       <scope>runtime</scope>
-   </dependency>
+            <!-- Test Dependencies -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.1</version>
+                <type>jar</type>
+                <scope>test</scope>
+            </dependency>
 
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <type>jar</type>
-      <scope>test</scope>
-    </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.10.0</version>
+                <scope>test</scope>
+            </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
-      <type>jar</type>
-      <scope>test</scope>
-    </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-    </dependencies>
-  </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.8.1</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.18.0</version>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
As there has been non-backwards compatible changes, especially after Java 9, in regards to how Mockito can, and is allowed, to mock things, I was forced to upgrade Mockito, which also forced me to move to Java 11 as the minimum version. If not, it seems that people would be stuck on using Java 8 for this library with very old versions of e.g. mockito.

Java 8, althoug still supported, is way old so let's move forward. Let's face it, Java 11 is also pretty old at this point.