### PR TITLE
Setting the min Java version to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
An upcoming PR is forcing pkts.io to move to Java 16 (for good reasons), but as I'd rather have an LTS release, I am preemptively forcing the version to Java 17.