### PR TITLE
Fix an RTP packet extension header reader

### DIFF
--- a/pkts-core/src/main/java/io/pkts/framer/RTPFramer.java
+++ b/pkts-core/src/main/java/io/pkts/framer/RTPFramer.java
@@ -102,8 +102,8 @@ public final class RTPFramer implements Framer<TransportPacket, RtpPacket> {
 
             if (hasExtension) {
                 final short extensionHeaders = buffer.readShort();
-                final int length = buffer.readUnsignedShort();
-                final Buffer extensionData = buffer.readBytes(length);
+                final int length = buffer.readUnsignedShort();  // RFC 3550: the number of 32-bit words in the extension
+                final Buffer extensionData = buffer.readBytes(4 * length);
             }
 
             if (hasPadding || hasExtension || csrcCount > 0) {


### PR DESCRIPTION
From RFC 3550, section [3.5.1](https://datatracker.ietf.org/doc/html/rfc3550#section-5.3.1)

> The header extension contains a 16-bit length field that counts the number of 32-bit words in the extension

The current code interprets the Length field value as a number of 8-bit blocks. This PR brings the code in accordance with RFC.

Without this fix payload is incorrect in case of the Extension Bit set to 1.